### PR TITLE
Introduce a cache to identify visited types

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -3757,7 +3757,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
 
         BType intersectionType = types.getTypeIntersection(
                 Types.IntersectionContext.compilerInternalNonGenerativeIntersectionContext(),
-                expressionType, testType, env);
+                expressionType, testType, env, new LinkedHashSet<>());
 
         if (intersectionType != symTable.semanticError) {
             return true;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -1999,7 +1999,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     private void addVarIfInferredTypeIncludesError(BLangSimpleVariable variable) {
         BType typeIntersection =
                 types.getTypeIntersection(Types.IntersectionContext.compilerInternalIntersectionContext(),
-                                          variable.type, symTable.errorType, env);
+                                          variable.type, symTable.errorType, env, new LinkedHashSet<>());
         if (typeIntersection != null &&
                 typeIntersection != symTable.semanticError && typeIntersection != symTable.noType) {
             unusedErrorVarsDeclaredWithVar.put(variable.symbol, variable.pos);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -2451,7 +2451,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         BType bindingPatternType = wildCardBindingPattern.type;
         BType intersectionType = types.getTypeIntersection(
                 Types.IntersectionContext.compilerInternalIntersectionContext(),
-                bindingPatternType, symTable.anyType, this.env);
+                bindingPatternType, symTable.anyType, this.env, new LinkedHashSet<>());
         if (intersectionType == symTable.semanticError) {
             wildCardBindingPattern.type = symTable.noType;
             return;
@@ -2480,7 +2480,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         }
         BTupleType listBindingPatternType = new BTupleType(listMemberTypes);
 
-        if (listBindingPattern.restBindingPattern != null) {
+        if (listBindingPattern.restBindingPattern != null) {Types.java:3487
             BLangRestBindingPattern restBindingPattern = listBindingPattern.restBindingPattern;
             BType restType = symTable.anyOrErrorType;
             restBindingPattern.type = new BArrayType(restType);
@@ -2867,7 +2867,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
 
         BType intersectionType = types.getTypeIntersection(
                 Types.IntersectionContext.compilerInternalIntersectionContext(),
-                matchExprType, symTable.anyType, this.env);
+                matchExprType, symTable.anyType, this.env, new LinkedHashSet<>());
         if (intersectionType == symTable.semanticError) {
             wildCardMatchPattern.type = symTable.noType;
             return;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -2092,7 +2092,7 @@ public class SymbolResolver extends BLangNodeVisitor {
             return lhsType;
         }
 
-        return types.getTypeIntersection(intersectionContext, lhsType, rhsType, env);
+        return types.getTypeIntersection(intersectionContext, lhsType, rhsType, env, new LinkedHashSet<>());
     }
 
     boolean validateInferTypedescParams(Location pos, List<? extends BLangVariable> parameters, BType retType) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeNarrower.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeNarrower.java
@@ -323,13 +323,17 @@ public class TypeNarrower extends BLangNodeVisitor {
         BType trueType, falseType;
         var nonLoggingContext = Types.IntersectionContext.compilerInternalNonGenerativeIntersectionContext();
         if (operator == OperatorKind.AND) {
-            trueType = types.getTypeIntersection(nonLoggingContext, lhsTrueType, rhsTrueType, this.env);
-            BType tmpType = types.getTypeIntersection(nonLoggingContext, lhsTrueType, rhsFalseType, this.env);
+            trueType = types.getTypeIntersection(nonLoggingContext, lhsTrueType, rhsTrueType, this.env,
+                    new LinkedHashSet<>());
+            BType tmpType = types.getTypeIntersection(nonLoggingContext, lhsTrueType, rhsFalseType, this.env,
+                    new LinkedHashSet<>());
             falseType = getTypeUnion(lhsFalseType, tmpType);
         } else {
-            BType tmpType = types.getTypeIntersection(nonLoggingContext, lhsFalseType, rhsTrueType, this.env);
+            BType tmpType = types.getTypeIntersection(nonLoggingContext, lhsFalseType, rhsTrueType, this.env,
+                    new LinkedHashSet<>());
             trueType = getTypeUnion(lhsTrueType, tmpType);
-            falseType = types.getTypeIntersection(nonLoggingContext, lhsFalseType, rhsFalseType, this.env);
+            falseType = types.getTypeIntersection(nonLoggingContext, lhsFalseType, rhsFalseType, this.env,
+                    new LinkedHashSet<>());
         }
         return new NarrowedTypes(trueType, falseType);
     }
@@ -422,9 +426,11 @@ public class TypeNarrower extends BLangNodeVisitor {
         BType falseType;
         if (expr.getKind() == NodeKind.BINARY_EXPR && ((BLangBinaryExpr) expr).opKind == OperatorKind.NOT_EQUAL) {
             trueType = types.getRemainingType(varSymbol.type, narrowWithType);
-            falseType = types.getTypeIntersection(nonLoggingContext, varSymbol.type, narrowWithType, this.env);
+            falseType = types.getTypeIntersection(nonLoggingContext, varSymbol.type, narrowWithType, this.env,
+                    new LinkedHashSet<>());
         } else {
-            trueType = types.getTypeIntersection(nonLoggingContext, varSymbol.type, narrowWithType, this.env);
+            trueType = types.getTypeIntersection(nonLoggingContext, varSymbol.type, narrowWithType, this.env,
+                    new LinkedHashSet<>());
             falseType = types.getRemainingType(varSymbol.type, narrowWithType);
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Unifier.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Unifier.java
@@ -860,7 +860,8 @@ public class Unifier implements BTypeVisitor<BType, BType> {
 
     private boolean hasIntersection(BType t1, BType t2) {
         BType typeIntersection =
-                types.getTypeIntersection(Types.IntersectionContext.compilerInternalIntersectionContext(), t1, t2, env);
+                types.getTypeIntersection(Types.IntersectionContext.compilerInternalIntersectionContext(), t1, t2, env,
+                        new LinkedHashSet<>());
         return typeIntersection != null && typeIntersection != symbolTable.semanticError;
     }
 


### PR DESCRIPTION
This fixes a stack overflow in getIntersection method.


## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
